### PR TITLE
kingst-la2016: do not zero pad fpga bitstream

### DIFF
--- a/firmware/kingst-la/sigrok-fwextract-kingst-la2016
+++ b/firmware/kingst-la/sigrok-fwextract-kingst-la2016
@@ -192,5 +192,5 @@ if __name__ == "__main__":
     res = qt_resources(sys.argv[1])
 
     writer = res_writer(res)
-    writer.extract("fwfpga/LA2016A", "kingst-la2016a-fpga.bitstream", zero_pad_to=180224)
+    writer.extract("fwfpga/LA2016A", "kingst-la2016a-fpga.bitstream")
     writer.extract_re(r"fwusb/fw(.*)", r"kingst-la-\1.fw", decoder=maybe_intel_hex_as_blob)


### PR DESCRIPTION
zero padding to 180224 will be done by uploader(/libsigrok).
to get same behaviour as vendors software uploader will need to know this
exact file-size -- without zero padding.

[related to bug #1559]