### PR TITLE
Fix for installing 64bit Windows programs into 'Program Files' instea…

### DIFF
--- a/cross-compile/mingw/sigrok-cross-mingw
+++ b/cross-compile/mingw/sigrok-cross-mingw
@@ -225,7 +225,11 @@ cd sigrok-cli
 ./configure $C
 make $PARALLEL $V
 make install $V
-makensis contrib/sigrok-cli_cross.nsi
+if [ $TARGET = "i686" ]; then
+	makensis contrib/sigrok-cli_cross.nsi
+else
+	makensis -DPE64=1 contrib/sigrok-cli_cross.nsi
+fi
 cd ..
 
 # PulseView
@@ -245,6 +249,10 @@ if [ $DEBUG = 1 ]; then
 else
 	make install/strip $V
 fi
-makensis contrib/pulseview_cross.nsi
+if [ $TARGET = "i686" ]; then
+        makensis contrib/pulseview_cross.nsi
+else
+        makensis -DPE64=1 contrib/pulseview_cross.nsi
+fi
 cd ..
 


### PR DESCRIPTION
…d of 'Program Files (x86)'