### PR TITLE
Fix build description in cross-compile/mingw/README

### DIFF
--- a/cross-compile/mingw/README
+++ b/cross-compile/mingw/README
@@ -46,7 +46,7 @@ Build all required packages:
 
  $ make MXE_TARGETS=i686-w64-mingw32.static.posix \
    MXE_PLUGIN_DIRS=plugins/examples/qt5-freeze \
-   gcc glib libzip libusb1 libftdi1 hidapi glibmm qtbase qtimageformats
+   gcc glib libzip libusb1 libftdi1 hidapi glibmm qtbase qtimageformats \
    qtsvg qttranslations boost check gendef libieee1284 \
    qtbase_CONFIGURE_OPTS='-no-sql-mysql'
 


### PR DESCRIPTION
The build description could be used to enter the command in the bash. Unfortunately the last version missed a backslash as continuation character. 
Only a minor change, but for the sake of convenience and correctness.