### PR TITLE
Sigrok fwextract kingst la2016 fixup extraction

### DIFF
--- a/firmware/kingst-la/README
+++ b/firmware/kingst-la/README
@@ -1,0 +1,70 @@
+SIGROK-FWEXTRACT-KINGST-LA20General Commands SIGROK-FWEXTRACT-KINGST-LA2016(1)
+
+
+
+NAME
+       sigrok-fwextract-kingst-la2016  -  Extract  Kingst firmware from vendor
+       software
+
+SYNOPSIS
+       sigrok-fwextract-kingst-la2016 [FILE]
+
+DESCRIPTION
+       This tool extracts the FX2 MCU firmware and  FPGA  bitstreams  for  the
+       Kingst  LA2016/LA1016  USB  logic  analyzers  from the vendor software.
+       These analyzers share the  same  USB  VID:PID  and  use  the  same  FX2
+       firmware.   The  correct  FPGA  bitstream  is selected by the libsigrok
+       driver after loading the FX2 firmware and reading the device identifier
+       from EEPROM.
+
+       Download  the Linux version of the vendor software from [1], and unpack
+       it to find the main binary called "KingstVIS". To extract the  firmware
+       and bitstreams, run the following commands:
+
+         $ tar -xzf KingstVIS_v3.5.0_linux.tar.gz KingstVIS
+
+         $ sigrok-fwextract-kingst-la2016 KingstVIS/KingstVIS
+         saved 5430 bytes to kingst-la-01a2.fw (crc32=720551a9)
+         saved 178362 bytes to kingst-la2016a1-fpga.bitstream (crc32=7cc894fa)
+         saved 178542 bytes to kingst-la2016-fpga.bitstream (crc32=20694ff1)
+         saved 178379 bytes to kingst-la1016a1-fpga.bitstream (crc32=166866be)
+         saved 178151 bytes to kingst-la1016-fpga.bitstream (crc32=7db70001)
+
+       Copy  the above firmware and bitstream files to the location where lib-
+       sigrok expects to find firmware files.  By  default  this  is  /usr/lo-
+       cal/share/sigrok-firmware.
+
+OPTIONS
+       None.
+
+EXIT STATUS
+       Exits with 0 on success, 1 on most failures.
+
+SEE ALSO
+       sigrok-fwextract-saleae-logic16(1)
+       sigrok-fwextract-dreamsourcelab-dslogic(1)
+       sigrok-fwextract-hantek-dso(1)
+       sigrok-fwextract-lecroy-logicstudio(1)
+       sigrok-fwextract-sysclk-lwla1016(1)
+       sigrok-fwextract-sysclk-lwla1034(1)
+
+BUGS
+       Please  report any bugs via Bugzilla (http://sigrok.org/bugzilla) or on
+       the sigrok-devel mailing list (sigrok-devel@lists.souceforge.net).
+
+LICENSE
+       This program is covered by the GNU General Public License  (GPL),  ver-
+       sion 3 or later.
+
+AUTHORS
+       Please see the individual source code files.
+
+NOTES
+        1. Vendor website
+           http://www.qdkingst.com/download
+           MD5 of v3.5.0: 812bbd37a16d315a489ca33ea2868a36
+
+
+
+
+                                 Mar 13, 2021SIGROK-FWEXTRACT-KINGST-LA2016(1)

--- a/firmware/kingst-la/make-readme.sh
+++ b/firmware/kingst-la/make-readme.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+groff -Tascii -man sigrok-fwextract-kingst-la2016.1 | col -bx > README
+cat README
+

--- a/firmware/kingst-la/sigrok-fwextract-kingst-la2016
+++ b/firmware/kingst-la/sigrok-fwextract-kingst-la2016
@@ -24,6 +24,7 @@ import re
 import struct
 import codecs
 import importlib.util
+import zlib
 
 # reuse parseelf.py module from saleae-logic16:
 fwdir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -132,7 +133,8 @@ class res_writer(object):
             data += b"\0" * (zero_pad_to - len(data))
         with open(fn, "wb") as fp:
             fp.write(data)
-        print("saved %d bytes to %s" % (len(data), fn))
+        data_crc32 = zlib.crc32(data) & 0xffffffff
+        print("saved %d bytes to %s (crc32=%08x)" % (len(data), fn, data_crc32))
 
     def extract(self, res_fn, out_fn, decoder=None, zero_pad_to=None):
         self._write_file(out_fn, self.res.get_resource(res_fn), decoder=decoder, zero_pad_to=zero_pad_to)
@@ -192,5 +194,31 @@ if __name__ == "__main__":
     res = qt_resources(sys.argv[1])
 
     writer = res_writer(res)
-    writer.extract("fwfpga/LA2016A", "kingst-la2016a-fpga.bitstream")
-    writer.extract_re(r"fwusb/fw(.*)", r"kingst-la-\1.fw", decoder=maybe_intel_hex_as_blob)
+
+    '''
+    05-APR-2021
+    This extraction script has been tested with the
+    vendor software versions v3.5.0 and v3.5.1
+    These files were extracted and tested successfully:
+    saved 5430 bytes to kingst-la-01a2.fw (crc32=720551a9)
+    saved 178362 bytes to kingst-la2016a1-fpga.bitstream (crc32=7cc894fa)
+    saved 178542 bytes to kingst-la2016-fpga.bitstream (crc32=20694ff1)
+    saved 178379 bytes to kingst-la1016a1-fpga.bitstream (crc32=166866be)
+    saved 178151 bytes to kingst-la1016-fpga.bitstream (crc32=7db70001)
+    '''
+
+    # extract all firmware and fpga bitstreams
+    # writer.extract_re(r"fwfpga/(.*)", r"kingst-\1-fpga.bitstream")
+    # writer.extract_re(r"fwusb/fw(.*)", r"kingst-la-\1.fw", decoder=maybe_intel_hex_as_blob)
+
+    # extract fx2 mcu firmware for both the la2016 and la1016
+    # note that 0x01a2 is the usb pid for both of these devices
+    writer.extract_re("fwusb/fw01A2", "kingst-la-01a2.fw", decoder=maybe_intel_hex_as_blob)
+
+    # extract fpga bitstreams for la2016
+    # there are two bitstreams, newer hardware uses the 'a1' bitstream
+    writer.extract_re("fwfpga/LA2016(.*)", r"kingst-la2016\1-fpga.bitstream")
+
+    # extract fpga bitstreams for la1016
+    # there are two bitstreams, newer hardware uses the 'a1' bitstream
+    writer.extract_re("fwfpga/LA1016(.*)", r"kingst-la1016\1-fpga.bitstream")

--- a/firmware/kingst-la/sigrok-fwextract-kingst-la2016.1
+++ b/firmware/kingst-la/sigrok-fwextract-kingst-la2016.1
@@ -1,33 +1,35 @@
-.TH SIGROK\-FWEXTRACT\-KINGST\-LA2016 1 "Mar 21, 2020"
+.TH SIGROK\-FWEXTRACT\-KINGST\-LA2016 1 "Mar 13, 2021"
 .SH "NAME"
-sigrok\-fwextract\-kingst\-la2016 \- Extract Kingst LA2016 firmware
+sigrok\-fwextract\-kingst\-la2016 \- Extract Kingst firmware from vendor software
 .SH "SYNOPSIS"
 .B sigrok\-fwextract\-kingst\-la2016 [FILE]
 .SH "DESCRIPTION"
-This tool extracts FX2 firmware and FPGA bitstreams from the vendor
-software for the Kingst LA2016 USB logic analyzer. Download the Linux
-version from[1], and unpack it to find the main binary called "KingstVIS".
+This tool extracts the FX2 MCU firmware and FPGA bitstreams for the Kingst
+LA2016/LA1016 USB logic analyzers from the vendor software. These
+analyzers share the same USB VID:PID and use the same FX2 firmware.
+The correct FPGA bitstream is selected by the libsigrok driver after
+loading the FX2 firmware and reading the device identifier from EEPROM.
 .PP
-In order to extract the firmware/bitstreams, run the following command:
+Download the Linux version of the vendor software from [1], and unpack
+it to find the main binary called "KingstVIS". To extract the
+firmware and bitstreams, run the following commands:
 .PP
-.B "  $ tar -xzf KingstVIS_v3.4.0.tar.gz KingstVIS/KingstVIS"
+.B "  $ tar -xzf KingstVIS_v3.5.0_linux.tar.gz KingstVIS"
 .PP
 .B "  $ sigrok-fwextract-kingst-la2016 KingstVIS/KingstVIS"
 .br
-.RB "  saved 177666 bytes to kingst-la2016a-fpga.bitstream
+.RB "  saved 5430 bytes to kingst-la-01a2.fw (crc32=720551a9)"
 .br
-.RB "  saved 5350 bytes to kingst-la-01a1.fw"
+.RB "  saved 178362 bytes to kingst-la2016a1-fpga.bitstream (crc32=7cc894fa)"
 .br
-.RB "  saved 5430 bytes to kingst-la-01a2.fw"
+.RB "  saved 178542 bytes to kingst-la2016-fpga.bitstream (crc32=20694ff1)"
 .br
-.RB "  saved 5718 bytes to kingst-la-01a3.fw"
+.RB "  saved 178379 bytes to kingst-la1016a1-fpga.bitstream (crc32=166866be)"
 .br
-.RB "  saved 142412 bytes to kingst-la-01a4.fw"
-.br
-.RB "  saved 5452 bytes to kingst-la-03a1.fw"
+.RB "  saved 178151 bytes to kingst-la1016-fpga.bitstream (crc32=7db70001)"
 .PP
-Copy the resulting files over to the location where libsigrok expects
-to find its firmware files. By default this is
+Copy the above firmware and bitstream files to the location where libsigrok
+expects to find firmware files. By default this is
 .BR /usr/local/share/sigrok-firmware .
 .SH OPTIONS
 None.
@@ -61,4 +63,5 @@ Vendor website
 .RS 4
 .RB http://www.qdkingst.com/download
 .br
-\%MD5 of v3.4.0: ca407133cb83b700983d2b704a4255c2
+\%MD5 of v3.5.0: 812bbd37a16d315a489ca33ea2868a36
+


### PR DESCRIPTION
This fixes extraction of the fpga bitstream for LA2016 (trivial stream name change by vendor broke it, I assume).
This pr also extracts other bitstreams for required for different variations of this device, shows crc32 of extracted files and adds a README generated from the (updated) groff file.