### PR TITLE
Update sigrok-fwextract-kingst-la2016 typo

### DIFF
--- a/firmware/kingst-la/sigrok-fwextract-kingst-la2016
+++ b/firmware/kingst-la/sigrok-fwextract-kingst-la2016
@@ -192,5 +192,5 @@ if __name__ == "__main__":
     res = qt_resources(sys.argv[1])
 
     writer = res_writer(res)
-    writer.extract("fwfpga/LA2016A", "kingst-la2016a-fpga.bitstream")
+    writer.extract("fwfpga/LA2016A1", "kingst-la2016a-fpga.bitstream")
     writer.extract_re(r"fwusb/fw(.*)", r"kingst-la-\1.fw", decoder=maybe_intel_hex_as_blob)


### PR DESCRIPTION
corrected a little typo that stops the script from extracting the FW.
Credit goes to these guys: https://sourceforge.net/p/sigrok/mailman/message/37223882/