### PR TITLE
cross-compile/macosx: Set DYLD_LIBRARY_PATH

### DIFF
--- a/cross-compile/macosx/contrib/pulseview
+++ b/cross-compile/macosx/contrib/pulseview
@@ -20,6 +20,7 @@
 
 DIR="$(dirname "$0")"
 cd "$DIR"
+export DYLD_LIBRARY_PATH="../Frameworks"
 export PYTHONHOME="../Frameworks/Python.framework/Versions/3.7"
 export SIGROK_FIRMWARE_DIR="../share/sigrok-firmware"
 export SIGROKDECODE_DIR="../share/libsigrokdecode/decoders"

--- a/cross-compile/macosx/contrib/sigrok-cli
+++ b/cross-compile/macosx/contrib/sigrok-cli
@@ -20,6 +20,7 @@
 
 DIR="$(dirname "$0")"
 cd "$DIR"
+export DYLD_LIBRARY_PATH="../Frameworks"
 export PYTHONHOME="../Frameworks/Python.framework/Versions/3.7"
 export SIGROK_FIRMWARE_DIR="../share/sigrok-firmware"
 export SIGROKDECODE_DIR="../share/libsigrokdecode/decoders"


### PR DESCRIPTION
After a prior change to the dynamic library path location users have reported issues of nightly builds crashing on MacOS:

 - #1633
 - #1627
 - #1651
 - #1744

This change, mentioned by Andrea Leofreddi in #1633, hints PulseView and sigrok-cli as to the correct location of dynamic libraries through the addition of an environment variable to the startup script.