### PR TITLE
px-logic: Add firmware extractor

### DIFF
--- a/firmware/dreamsourcelab-dslogic/sigrok-fwextract-dreamsourcelab-dslogic.1
+++ b/firmware/dreamsourcelab-dslogic/sigrok-fwextract-dreamsourcelab-dslogic.1
@@ -38,6 +38,8 @@ Exits with 0 on success, 1 on most failures.
 .br
 \fBsigrok\-fwextract\-lecroy\-logicstudio\fP(1)
 .br
+\fBsigrok\-fwextract\-px\-logic\fP(1)
+.br
 \fBsigrok\-fwextract\-saleae\-logic16\fP(1)
 .br
 \fBsigrok\-fwextract\-sysclk\-lwla1016\fP(1)

--- a/firmware/hantek-dso/sigrok-fwextract-hantek-dso.1
+++ b/firmware/hantek-dso/sigrok-fwextract-hantek-dso.1
@@ -32,6 +32,8 @@ Exits with 0 on success, 1 on most failures.
 .br
 \fBsigrok\-fwextract\-lecroy\-logicstudio\fP(1)
 .br
+\fBsigrok\-fwextract\-px\-logic\fP(1)
+.br
 \fBsigrok\-fwextract\-saleae\-logic16\fP(1)
 .br
 \fBsigrok\-fwextract\-sysclk\-lwla1016\fP(1)

--- a/firmware/kingst-la/sigrok-fwextract-kingst-la2016.1
+++ b/firmware/kingst-la/sigrok-fwextract-kingst-la2016.1
@@ -42,6 +42,8 @@ Exits with 0 on success, 1 on most failures.
 .br
 \fBsigrok\-fwextract\-lecroy\-logicstudio\fP(1)
 .br
+\fBsigrok\-fwextract\-px\-logic\fP(1)
+.br
 \fBsigrok\-fwextract\-saleae\-logic16\fP(1)
 .br
 \fBsigrok\-fwextract\-sysclk\-lwla1016\fP(1)

--- a/firmware/px-logic/sigrok-fwextract-px-logic
+++ b/firmware/px-logic/sigrok-fwextract-px-logic
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+##
+## This file is part of the sigrok-util project.
+##
+## Copyright (C) 2026 dogtopus <dogtopus@users.noreply.github.com>
+##
+## This program is free software; you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation; either version 3 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with this program; if not, see <http://www.gnu.org/licenses/>.
+##
+
+import hashlib
+import os
+import shutil
+import sys
+import urllib.parse
+import urllib.request
+
+
+COMMIT = '0ac8c55bc86cf90f41496dcb422caa518ac4d4b0'
+FILES = [
+    {
+        'name': 'px-logic-mcu.fw',
+        'original_name': 'SCI_LOGIC.bin',
+        'sha256': '75d1d38a9ea4bddef6bd41637939ee27028b75c86bbf504350fddad1129aa5ae',
+    }, {
+        'name': 'px-logic-fpga-stage1.fw',
+        'original_name': 'hspi_ddr_RST.bin',
+        'sha256': '1b4bf398a4cafd9d2fb0f118982ebc064db22ebdd50db36097610f82ec45ec69',
+    }, {
+        'name': 'px-logic-fpga-stage2.fw',
+        'original_name': 'hspi_ddr.bin',
+        'sha256': 'aa2fb803a46886dc77633c7e6fec87ca0a699a3db6a7d22732d3084bd76dd514',
+    },
+]
+REPO_RES_URL = 'https://github.com/PXLogic/PXView/raw/{commit}/PXView/res/'.format(commit=COMMIT)
+
+
+if __name__ == '__main__':
+    for file in FILES:
+        url = urllib.parse.urljoin(REPO_RES_URL, file['original_name'])
+        target = os.path.join('.', file['name'])
+        print('Downloading', '{}...'.format(file['name']))
+        urllib.request.urlretrieve(url, filename=target)
+        with open(target, 'rb') as f:
+            sha256 = hashlib.sha256(f.read())
+            if sha256.hexdigest() != file['sha256']:
+                print(file['name'], 'failed validation. Aborting.')
+                sys.exit(1)

--- a/firmware/px-logic/sigrok-fwextract-px-logic
+++ b/firmware/px-logic/sigrok-fwextract-px-logic
@@ -26,12 +26,12 @@ import urllib.parse
 import urllib.request
 
 
-COMMIT = '0ac8c55bc86cf90f41496dcb422caa518ac4d4b0'
+COMMIT = '8be58dea74acc300b772915b3adc368691db3075'
 FILES = [
     {
         'name': 'px-logic-mcu.fw',
         'original_name': 'SCI_LOGIC.bin',
-        'sha256': '75d1d38a9ea4bddef6bd41637939ee27028b75c86bbf504350fddad1129aa5ae',
+        'sha256': 'da9b1e4912d3bc3757aa1d1ef71c4a19971bdc7ab66a6d31a9754fa82769ceaa',
     }, {
         'name': 'px-logic-fpga-stage1.fw',
         'original_name': 'hspi_ddr_RST.bin',

--- a/firmware/px-logic/sigrok-fwextract-px-logic.1
+++ b/firmware/px-logic/sigrok-fwextract-px-logic.1
@@ -1,18 +1,24 @@
-.TH SIGROK\-FWEXTRACT\-LECROY\-LOGICSTUDIO 1 "Oct 25, 2015"
+.TH SIGROK\-FWEXTRACT\-PX\-LOGIC 1 "Feb 25 2026"
 .SH "NAME"
-sigrok\-fwextract\-lecroy\-logicstudio \- Extract LeCroy LogicStudio firmware
+sigrok\-fwextract\-px\-logic \- Extract PX Logic firmware
 .SH "SYNOPSIS"
-.B sigrok\-fwextract\-lecroy\-logicstudio [FILE]
+.B sigrok\-fwextract\-px\-logic
 .SH "DESCRIPTION"
-This tool extracts firmware from the Windows software that ships with the LeCroy LogicStudio logic analyzer. It is called with the path to
-.B LS16Lib.dll
-as its only argument, e.g.:
+This tool downloads firmware and FPGA bitstreams from the vendor
+software GitHub repository for the PX Logic USB logic analyzer.
 .PP
-.B "  $ sigrok-fwextract-lecroy-logicstudio /path/to/LogicStudio/LS16Lib.dll"
+In order to extract the firmware/bitstreams, run the following command:
 .PP
-The program will then write two FPGA bitstream files to the current directory.
-Copy these over to the location where libsigrok expects to find its firmware
-files. By default this is
+.B "  $ sigrok-fwextract-px-logic"
+.br
+.RB "  Downloading px-logic-mcu.fw..."
+.br
+.RB "  Downloading px-logic-fpga-stage1.fw..."
+.br
+.RB "  Downloading px-logic-fpga-stage2.fw..."
+.PP
+Copy the resulting files over to the location where libsigrok expects
+to find its firmware files. By default this is
 .BR /usr/local/share/sigrok-firmware .
 .SH OPTIONS
 None.
@@ -25,7 +31,7 @@ Exits with 0 on success, 1 on most failures.
 .br
 \fBsigrok\-fwextract\-kingst\-la2016\fP(1)
 .br
-\fBsigrok\-fwextract\-px\-logic\fP(1)
+\fBsigrok\-fwextract\-lecroy\-logicstudio\fP(1)
 .br
 \fBsigrok\-fwextract\-saleae\-logic16\fP(1)
 .br

--- a/firmware/saleae-logic16/sigrok-fwextract-saleae-logic16.1
+++ b/firmware/saleae-logic16/sigrok-fwextract-saleae-logic16.1
@@ -35,6 +35,8 @@ Exits with 0 on success, 1 on most failures.
 .br
 \fBsigrok\-fwextract\-lecroy\-logicstudio\fP(1)
 .br
+\fBsigrok\-fwextract\-px\-logic\fP(1)
+.br
 \fBsigrok\-fwextract\-sysclk\-lwla1016\fP(1)
 .br
 \fBsigrok\-fwextract\-sysclk\-lwla1034\fP(1)

--- a/firmware/sysclk-lwla/sigrok-fwextract-sysclk-lwla1016.1
+++ b/firmware/sysclk-lwla/sigrok-fwextract-sysclk-lwla1016.1
@@ -28,6 +28,8 @@ Exits with 0 on success, 1 on most failures.
 .br
 \fBsigrok\-fwextract\-lecroy\-logicstudio\fP(1)
 .br
+\fBsigrok\-fwextract\-px\-logic\fP(1)
+.br
 \fBsigrok\-fwextract\-saleae\-logic16\fP(1)
 .br
 \fBsigrok\-fwextract\-sysclk\-lwla1034\fP(1)

--- a/firmware/sysclk-lwla/sigrok-fwextract-sysclk-lwla1034.1
+++ b/firmware/sysclk-lwla/sigrok-fwextract-sysclk-lwla1034.1
@@ -28,6 +28,8 @@ Exits with 0 on success, 1 on most failures.
 .br
 \fBsigrok\-fwextract\-lecroy\-logicstudio\fP(1)
 .br
+\fBsigrok\-fwextract\-px\-logic\fP(1)
+.br
 \fBsigrok\-fwextract\-saleae\-logic16\fP(1)
 .br
 \fBsigrok\-fwextract\-sysclk\-lwla1016\fP(1)


### PR DESCRIPTION
This downloads firmware version 0x56900027 from official vendor software GitHub repo to the current directory. The user then needs to copy those files to a sigrok firmware search path they prefer.

The firmware files will be renamed according to the sigrok naming convention (i.e. `<device>-<type>.fw`).