### PR TITLE
sigrok-fwextract-dreamsourcelab-dslogic: Add DSLogic U3Pro16 support

### DIFF
--- a/firmware/dreamsourcelab-dslogic/sigrok-fwextract-dreamsourcelab-dslogic
+++ b/firmware/dreamsourcelab-dslogic/sigrok-fwextract-dreamsourcelab-dslogic
@@ -49,3 +49,12 @@ $WGET $FWURL/DSLogicPlus.fw -O $FWDIR/dreamsourcelab-dslogic-plus-fx2.fw
 
 $WGET $FWURL/DSLogicBasic.bin -O $FWDIR/dreamsourcelab-dslogic-basic-fpga.fw
 $WGET $FWURL/DSLogicBasic.fw -O $FWDIR/dreamsourcelab-dslogic-basic-fx2.fw
+
+# The DSLogic U3Pro16 (USB 3.0) was added to DSView well after the 0.97 set
+# above and is not present at that revision, so its FPGA bitstream is fetched
+# from a later, pinned DSView revision. The U3Pro16 has no dedicated FX2 loader;
+# it reuses the DSLogic Basic FX2 firmware extracted above, matching the
+# libsigrok dreamsourcelab-dslogic driver.
+FWURL_U3PRO16="https://github.com/DreamSourceLab/DSView/raw/2e9e2c8e726df4ef5687d39b83d4f797cc44b574/DSView/res"
+
+$WGET $FWURL_U3PRO16/DSLogicU3Pro16.bin -O $FWDIR/dreamsourcelab-dslogic-u3pro16-fpga.fw

--- a/firmware/dreamsourcelab-dslogic/sigrok-fwextract-dreamsourcelab-dslogic.1
+++ b/firmware/dreamsourcelab-dslogic/sigrok-fwextract-dreamsourcelab-dslogic.1
@@ -1,11 +1,11 @@
-.TH SIGROK\-FWEXTRACT\-DREAMSOURCELAB\-DSLOGIC 1 "Nov 21, 2017"
+.TH SIGROK\-FWEXTRACT\-DREAMSOURCELAB\-DSLOGIC 1 "Jun 23, 2026"
 .SH "NAME"
-sigrok\-fwextract\-dreamsourcelab\-dslogic \- Extract DreamSourceLab DSLogic / DSLogic Pro/Basic/Plus / DScope firmware
+sigrok\-fwextract\-dreamsourcelab\-dslogic \- Extract DreamSourceLab DSLogic / DSLogic Pro/Basic/Plus/U3Pro16 / DScope firmware
 .SH "SYNOPSIS"
 .B [PREFIX=...] sigrok\-fwextract\-dreamsourcelab\-dslogic
 .SH "DESCRIPTION"
 This tool downloads the vendor FX2 firmware and FPGA bitstreams
-for the DreamSourceLab DSLogic / DSLogic Pro/Basic/Plus / DScope devices from
+for the DreamSourceLab DSLogic / DSLogic Pro/Basic/Plus/U3Pro16 / DScope devices from
 the vendor's GitHub repository and installs them in the specified location.
 .PP
 In order to download/install the firmware/bitstreams, run the following command:


### PR DESCRIPTION
Fetch and install the FPGA bitstream for the DreamSourceLab DSLogic U3Pro16
(USB 3.0) as `dreamsourcelab-dslogic-u3pro16-fpga.fw`, the filename expected by
the libsigrok `dreamsourcelab-dslogic` driver.

The U3Pro16 was added to DSView after the pinned 0.97 firmware set this script
uses for the legacy devices, so it is not present at that revision. Its bitstream
is therefore fetched from a later, pinned DSView revision (`2e9e2c8e…`). The
device has no dedicated FX2 loader — it reuses the DSLogic Basic FX2 firmware
already extracted here, matching the driver.

The existing 0.97 `FWURL` is intentionally left unchanged: every legacy bitstream
differs at the newer revision, and `DSLogicPlus.fw` / `DSLogicBasic.fw` no longer
exist there, so only the new U3Pro16 bitstream is fetched from the newer pin.

Pairs with the libsigrok U3Pro16 driver support (sigrokproject/libsigrok#170).

Tested: the installed bitstream is byte-identical to the one used for a working
`sigrok-cli` capture on a physical U3Pro16.
